### PR TITLE
Oops, neither lecture actually compiled because the code was hidden. …

### DIFF
--- a/Lecture2.lagda
+++ b/Lecture2.lagda
@@ -7,9 +7,24 @@ data ℕ : Type where
   Nzero : ℕ
   Nsucc : ℕ → ℕ
 
+-- induction: for any dependent type P over ℕ, define a section of P
+-- built out of a term in P 0 and a section of P n → P(Nsucc n)
+ind-N : {P : ℕ → Type} → P Nzero → ((n : ℕ) → P n → P(Nsucc n)) → ((n : ℕ) → P n)
+ind-N p0 pS Nzero = p0
+ind-N p0 pS (Nsucc n) = pS n (ind-N p0 pS n)
+
+-- use the general induction principle to define addition
+-- in this case P is ℕ, the special non-dependent type over ℕ, and
+-- so sections of P (dependent functions Π_{x:ℕ} P(x)) are functions ℕ → ℕ
+add0 : ℕ → ℕ
+add0 n = n
+addS : ℕ → (ℕ → ℕ) → (ℕ → ℕ)
+addS n f m = Nsucc (f m)
+add : ℕ → ℕ → ℕ
+add = ind-N add0 addS
+
 _+_ : ℕ → ℕ → ℕ
-Nzero + n = n
-(Nsucc n) + m = Nsucc(n + m)
+n + m = add n m
 
 _**_ : ℕ → (ℕ → ℕ)
 Nzero ** n = Nzero

--- a/Lecture2.lagda
+++ b/Lecture2.lagda
@@ -1,32 +1,35 @@
+\begin{code}
 module Lecture2 where
 
-data ℕ : Set where
+Type = Set
+
+data ℕ : Type where
   Nzero : ℕ
   Nsucc : ℕ → ℕ
 
-_+_ : ℕ → (ℕ → ℕ)
-  Nzero + n = n
-  (Nsucc m) + m = Nsucc (n + m)
+_+_ : ℕ → ℕ → ℕ
+Nzero + n = n
+(Nsucc n) + m = Nsucc(n + m)
 
 _**_ : ℕ → (ℕ → ℕ)
-  Nzero ** n = Nzero
-  (Nsucc m) ** n = (m ** n) + n
+Nzero ** n = Nzero
+(Nsucc m) ** n = (m ** n) + n
 
 _^_ : ℕ → (ℕ → ℕ)
-  m ^ Nzero = Nsucc Nzero
-  m ^ (Nsucc n) = m * (m ^ n)
+m ^ Nzero = Nsucc Nzero
+m ^ (Nsucc n) = m ** (m ^ n)
 
 factorial : ℕ → ℕ
-  factorial Nzero = Nsucc Nzero
-  factorial (Nsucc m) = (Nsucc m) * (factorial m)
+factorial Nzero = Nsucc Nzero
+factorial (Nsucc m) = (Nsucc m) ** (factorial m)
 
 Nmax : ℕ → (ℕ → ℕ)
-  Nmax Nzero n = n
-  Nmax (Nsucc m) Nzero = Nsucc m
-  Nmax (Nsucc m) (Nsucc n) = Nsucc (Nmax m n)
+Nmax Nzero n = n
+Nmax (Nsucc m) Nzero = Nsucc m
+Nmax (Nsucc m) (Nsucc n) = Nsucc (Nmax m n)
 
 Nmin : ℕ → (ℕ → ℕ)
-  Nmin Nzero n = Nzero
-  Nmin (Nsucc m) Nzero = Nzero
-  Nmin (Nsucc m) (Nsucc n) = Nsucc (Nmin m n)
-
+Nmin Nzero n = Nzero
+Nmin (Nsucc m) Nzero = Nzero
+Nmin (Nsucc m) (Nsucc n) = Nsucc (Nmin m n)
+\end{code}

--- a/Lecture3.lagda
+++ b/Lecture3.lagda
@@ -4,28 +4,34 @@ module Lecture3 where
 import Lecture2
 open Lecture2
 
-data unit : Set where
+data unit : Type where
   star : unit
+𝟙 = unit
+ind-unit : {P : unit → Type} → P star → ((x : unit) → P x)
+ind-unit p star = p
 
-data empty : Set where
+data empty : Type where
+𝟘 = empty
+ind-empty : {P : empty → Type} → ((x : empty) → P x)
+ind-empty ()
 
-¬ : Set → Set
+¬ : Type → Type
 ¬ A = A → empty
 
-data coprod (A : Set) (B : Set) : Set where
+data coprod (A : Type) (B : Type) : Type where
   inl : A → coprod A B
   inr : B → coprod A B
 
-data Sigma (A : Set) (B : A → Set) : Set where
+data Sigma (A : Type) (B : A → Type) : Type where
   dpair : (x : A) → (B x → Sigma A B)
 
-data prod (A : Set) (B : Set) : Set where
+data prod (A : Type) (B : Type) : Type where
   pair : A → (B → prod A B)
 
-EqN : ℕ → (ℕ → Set)
-EqN Nzero Nzero = unit
-EqN Nzero (Nsucc n) = empty
-EqN (Nsucc m) Nzero = empty
+EqN : ℕ → (ℕ → Type)
+EqN Nzero Nzero = 𝟙
+EqN Nzero (Nsucc n) = 𝟘
+EqN (Nsucc m) Nzero = 𝟘
 EqN (Nsucc m) (Nsucc n) = EqN m n
 
 reflexive-EqN : (n : ℕ) → EqN n n
@@ -38,9 +44,14 @@ symmetric-EqN Nzero (Nsucc n) t = t
 symmetric-EqN (Nsucc n) Nzero t = t
 symmetric-EqN (Nsucc m) (Nsucc n) t = symmetric-EqN m n t
 
-{-
 transitive-EqN : (l m n : ℕ) → EqN l m → EqN m n → EqN l n
 transitive-EqN Nzero Nzero Nzero s t = star
+transitive-EqN (Nsucc n) Nzero Nzero s t = ind-empty s
+transitive-EqN Nzero (Nsucc n) Nzero s t = ind-empty s
+transitive-EqN Nzero Nzero (Nsucc n) s t = ind-empty t
+transitive-EqN (Nsucc l) (Nsucc m) Nzero s t = ind-empty t
+transitive-EqN (Nsucc l) Nzero (Nsucc n) s t = ind-empty s
+transitive-EqN Nzero (Nsucc m) (Nsucc n) s t = ind-empty s
 transitive-EqN (Nsucc l) (Nsucc m) (Nsucc n) s t = transitive-EqN l m n s t
--}
+
 \end{code}

--- a/Lecture3.lagda
+++ b/Lecture3.lagda
@@ -1,6 +1,8 @@
+\begin{code}
 module Lecture3 where
 
 import Lecture2
+open Lecture2
 
 data unit : Set where
   star : unit
@@ -8,7 +10,7 @@ data unit : Set where
 data empty : Set where
 
 ¬ : Set → Set
-  ¬ A = A → empty
+¬ A = A → empty
 
 data coprod (A : Set) (B : Set) : Set where
   inl : A → coprod A B
@@ -21,19 +23,24 @@ data prod (A : Set) (B : Set) : Set where
   pair : A → (B → prod A B)
 
 EqN : ℕ → (ℕ → Set)
-  EqN Nzero Nzero = unit
-  EqN Nzero (Nsucc n) = empty
-  EqN (Nsucc m) Nzero = empty
-  EqN (Nsucc m) (Nsucc n) = EqN m n
+EqN Nzero Nzero = unit
+EqN Nzero (Nsucc n) = empty
+EqN (Nsucc m) Nzero = empty
+EqN (Nsucc m) (Nsucc n) = EqN m n
 
-reflexive_EqN : (n : ℕ) → EqN n n
-  reflexive_EqN Nzero = star
-  reflexive_EqN (Nsucc n) = reflexive_EqN n
+reflexive-EqN : (n : ℕ) → EqN n n
+reflexive-EqN Nzero = star
+reflexive-EqN (Nsucc n) = reflexive-EqN n
 
-symmetric_EqN : (m n : ℕ) → EqN m n → EqN n m
-  symmetric_EqN Nzero Nzero t = t
-  symmetric_EqN (Nsucc m) (Nsucc n) t = symmetric_EqN m n t
+symmetric-EqN : (m n : ℕ) → EqN m n → EqN n m
+symmetric-EqN Nzero Nzero t = t
+symmetric-EqN Nzero (Nsucc n) t = t
+symmetric-EqN (Nsucc n) Nzero t = t
+symmetric-EqN (Nsucc m) (Nsucc n) t = symmetric-EqN m n t
 
-transitive_EqN : (l m n : ℕ) → EqN l m → EqN m n → EqN l n
-  transitive_EqN Nzero Nzero Nzero s t = star
-  transitive_EqN (Nsucc l) (Nsucc m) (Nsucc n) s t = transitive_EqN l m n s t
+{-
+transitive-EqN : (l m n : ℕ) → EqN l m → EqN m n → EqN l n
+transitive-EqN Nzero Nzero Nzero s t = star
+transitive-EqN (Nsucc l) (Nsucc m) (Nsucc n) s t = transitive-EqN l m n s t
+-}
+\end{code}


### PR DESCRIPTION
…The way .lagda works is that only text between \begin{code}...\end{code} is treated as agda. Fixing this led to a syntax error which is that function definitions are not indented like data constructors are. Then I had to change some underscores in names to dashes since underscore means "an argument goes here". Finally, agda then informed me that the definitions of symmetric-EqN and transitive-EqN were missing some definitions. I supplied them for symmetric-EqN but couldn't figure out transitive-EqN yet, so left it commented out.